### PR TITLE
Add confirmation before marking payments as paid

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -118,7 +118,9 @@ export const Dashboard: React.FC = () => {
   if (!user) return null;
 
   const onMarkPaid = (id: string) => {
-    commitMarkPaid({ variables: { paymentId: id }, onCompleted: refresh });
+    if (window.confirm('Mark this payment as received?')) {
+      commitMarkPaid({ variables: { paymentId: id }, onCompleted: refresh });
+    }
   };
 
   const onToggleAdmin = (id: string, isAdmin: boolean) => {


### PR DESCRIPTION
## Summary
- ask for confirmation before marking pending payments as received

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68b8eafc268c8331acefa2cc041545f0