### PR TITLE
feat: add sponsor-only flow

### DIFF
--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -3,6 +3,7 @@ import horseGates from '../assets/horse-gates.jpg'
 import auctionRace from '../assets/dust.jpg'
 import wagering from '../assets/two-racers.jpg'
 import whyItMatters from '../assets/yes-and-2024.jpg'
+import { Link } from 'react-router-dom'
 
 export const About: React.FC = () => {
   return (
@@ -16,6 +17,9 @@ export const About: React.FC = () => {
             </p>
             <p className="text-lg text-gray-700 mb-6">
               Proceeds benefit the <a href="https://noahbrave.org" target="_blank" rel="noopener noreferrer" className="text-noahbrave-600 hover:text-noahbrave-700 hover:underline">NoahBRAVE Foundation</a>, which provides personalized support, raises awareness, and funds research for children and families battling terminal brain cancer. By joining us, you help ensure families know they are seen, valued, loved, and never alone in their fight.
+            </p>
+            <p className="text-lg text-gray-700 mb-6">
+              Can't make it but still want to help? <Link to="/sponsor" className="text-noahbrave-600 hover:text-noahbrave-700 hover:underline">Become a sponsor</Link> and support the cause from anywhere.
             </p>
           </div>
           <div>

--- a/frontend/src/components/sponsor-flow/SponsorFlow.tsx
+++ b/frontend/src/components/sponsor-flow/SponsorFlow.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import UserDetailsStep from '../ticket-flow/UserDetailsStep';
+import SponsorStep from '../ticket-flow/SponsorStep';
+import SummaryStep from '../ticket-flow/SummaryStep';
+import VenmoStep from '../ticket-flow/VenmoStep';
+import { useSponsorFlowStore } from '../../store/sponsorFlow';
+
+const SponsorFlow: React.FC = () => {
+  const { step } = useParams();
+  const navigate = useNavigate();
+  const currentStep = useSponsorFlowStore((s) => s.currentStep);
+  const user = useSponsorFlowStore((s) => s.user);
+  const setUser = useSponsorFlowStore((s) => s.setUser);
+  const nextStep = useSponsorFlowStore((s) => s.nextStep);
+  const prevStep = useSponsorFlowStore((s) => s.prevStep);
+  const goToStep = useSponsorFlowStore((s) => s.goToStep);
+  const createUser = useSponsorFlowStore((s) => s.createUser);
+  const addSponsor = useSponsorFlowStore((s) => s.addSponsorToCart);
+  const removeSponsor = useSponsorFlowStore((s) => s.removeSponsorFromCart);
+  const cartRefreshKey = useSponsorFlowStore((s) => s.cartRefreshKey);
+  const checkout = useSponsorFlowStore((s) => s.checkoutCart);
+
+  useEffect(() => {
+    const n = Number(step);
+    if (!Number.isNaN(n) && n >= 1 && n <= 4 && n !== currentStep) {
+      goToStep(n);
+    }
+  }, [step, currentStep, goToStep]);
+
+  useEffect(() => {
+    const path = `/sponsor/${currentStep}`;
+    if (window.location.pathname !== path) {
+      navigate(path, { replace: true });
+    }
+  }, [currentStep, navigate]);
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 1:
+        return (
+          <UserDetailsStep
+            user={user}
+            onUserUpdate={setUser}
+            onNext={nextStep}
+            createUser={createUser}
+            title="Sponsor"
+            subtitle="Step 1 of 4 — Your details"
+          />
+        );
+      case 2:
+        return (
+          <SponsorStep
+            onBack={prevStep}
+            onContinue={nextStep}
+            subtitle="Step 2 of 4 — Sponsor the event"
+            addSponsor={addSponsor}
+            removeSponsor={removeSponsor}
+            cartRefreshKey={cartRefreshKey}
+          />
+        );
+      case 3:
+        return (
+          <SummaryStep
+            onBack={prevStep}
+            onNext={nextStep}
+            subtitle="Step 3 of 4 — Final summary"
+            cartRefreshKey={cartRefreshKey}
+            checkout={checkout}
+          />
+        );
+      case 4:
+        return <VenmoStep />;
+      default:
+        return null;
+    }
+  };
+
+  return renderStep();
+};
+
+export default SponsorFlow;
+

--- a/frontend/src/components/ticket-flow/SponsorStep.tsx
+++ b/frontend/src/components/ticket-flow/SponsorStep.tsx
@@ -18,12 +18,22 @@ const fileToBase64 = (file: File): Promise<string> => new Promise((resolve, reje
   reader.readAsDataURL(file);
 });
 
-interface Props { onBack: () => void; onContinue: () => void }
+interface Props {
+  onBack: () => void;
+  onContinue: () => void;
+  subtitle?: string;
+  addSponsor?: (companyName: string, amountDollars: number, companyLogoBase64?: string) => Promise<void>;
+  removeSponsor?: (sponsorId: string) => Promise<void>;
+  cartRefreshKey?: number;
+}
 
-const SponsorStep: React.FC<Props> = ({ onBack, onContinue }) => {
-  const addSponsor = useTicketFlowStore((s) => s.addSponsorToCart);
-  const removeSponsor = useTicketFlowStore((s) => s.removeSponsorFromCart);
-  const cartRefreshKey = useTicketFlowStore((s) => s.cartRefreshKey);
+const SponsorStep: React.FC<Props> = ({ onBack, onContinue, subtitle, addSponsor: addSponsorProp, removeSponsor: removeSponsorProp, cartRefreshKey: cartKeyProp }) => {
+  const storeAddSponsor = useTicketFlowStore((s) => s.addSponsorToCart);
+  const storeRemoveSponsor = useTicketFlowStore((s) => s.removeSponsorFromCart);
+  const storeCartKey = useTicketFlowStore((s) => s.cartRefreshKey);
+  const addSponsor = addSponsorProp ?? storeAddSponsor;
+  const removeSponsor = removeSponsorProp ?? storeRemoveSponsor;
+  const cartRefreshKey = cartKeyProp ?? storeCartKey;
   const data = useLazyLoadQuery<SponsorStepQuery>(SponsorQuery, {}, { fetchKey: cartRefreshKey, fetchPolicy: 'network-only' });
   const existing = data?.myCart?.sponsorInterests ?? [];
 
@@ -100,7 +110,7 @@ const SponsorStep: React.FC<Props> = ({ onBack, onContinue }) => {
     <div className="min-h-screen bg-noahbrave-50 font-body pb-32">
       <div className="checker-top h-3" style={{ backgroundColor: 'var(--brand)' }} />
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <StepHeader title="Sponsor" subtitle="Step 6 of 8 — Sponsor the event" />
+        <StepHeader title="Sponsor" subtitle={subtitle || 'Step 6 of 8 — Sponsor the event'} />
 
         <div className="bg-white rounded-2xl shadow-xl border border-noahbrave-200 p-8">
           <label className="flex items-start gap-3">

--- a/frontend/src/components/ticket-flow/SummaryStep.tsx
+++ b/frontend/src/components/ticket-flow/SummaryStep.tsx
@@ -20,11 +20,19 @@ const SummaryQuery = graphql`
   }
 `;
 
-interface Props { onBack: () => void; onNext: () => void }
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  subtitle?: string;
+  cartRefreshKey?: number;
+  checkout?: () => Promise<void>;
+}
 
-const SummaryStep: React.FC<Props> = ({ onBack, onNext }) => {
-  const cartRefreshKey = useTicketFlowStore((s) => s.cartRefreshKey);
-  const checkout = useTicketFlowStore((s) => s.checkoutCart);
+const SummaryStep: React.FC<Props> = ({ onBack, onNext, subtitle, cartRefreshKey: cartKeyProp, checkout: checkoutProp }) => {
+  const storeCartKey = useTicketFlowStore((s) => s.cartRefreshKey);
+  const storeCheckout = useTicketFlowStore((s) => s.checkoutCart);
+  const cartRefreshKey = cartKeyProp ?? storeCartKey;
+  const checkout = checkoutProp ?? storeCheckout;
   const [inFlight, setInFlight] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [seatingPreference, setSeatingPreference] = useState('');
@@ -64,7 +72,7 @@ const SummaryStep: React.FC<Props> = ({ onBack, onNext }) => {
     <div className="min-h-screen bg-noahbrave-50 font-body pb-12">
       <div className="checker-top h-3" style={{ backgroundColor: 'var(--brand)' }} />
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <StepHeader title="Review & Checkout" subtitle="Step 7 of 8 — Final summary" />
+        <StepHeader title="Review & Checkout" subtitle={subtitle || 'Step 7 of 8 — Final summary'} />
 
         <div className="bg-white rounded-2xl shadow-xl border border-noahbrave-200 p-8 space-y-6">
           {error && <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-red-800">{error}</div>}
@@ -133,15 +141,17 @@ const SummaryStep: React.FC<Props> = ({ onBack, onNext }) => {
             )}
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Seating preference (optional)</label>
-            <textarea
-              value={seatingPreference}
-              onChange={(e) => setSeatingPreference(e.target.value)}
-              className="w-full rounded-lg border px-3 py-2 border-gray-300 focus:outline-none focus:ring-2 focus:ring-noahbrave-600"
-              rows={3}
-            />
-          </div>
+          {cart?.tickets?.length ? (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Seating preference (optional)</label>
+              <textarea
+                value={seatingPreference}
+                onChange={(e) => setSeatingPreference(e.target.value)}
+                className="w-full rounded-lg border px-3 py-2 border-gray-300 focus:outline-none focus:ring-2 focus:ring-noahbrave-600"
+                rows={3}
+              />
+            </div>
+          ) : null}
 
           <div className="border-t pt-4 text-right">
             <div className="text-sm text-gray-600">Total</div>

--- a/frontend/src/components/ticket-flow/UserDetailsStep.tsx
+++ b/frontend/src/components/ticket-flow/UserDetailsStep.tsx
@@ -7,9 +7,12 @@ interface UserDetailsStepProps {
   user: User;
   onUserUpdate: (user: User) => void;
   onNext: () => void;
+  createUser?: (vars: { firstName: string; lastName: string; email: string }) => Promise<User>;
+  title?: string;
+  subtitle?: string;
 }
 
-const UserDetailsStep: React.FC<UserDetailsStepProps> = ({ user, onUserUpdate, onNext }) => {
+const UserDetailsStep: React.FC<UserDetailsStepProps> = ({ user, onUserUpdate, onNext, createUser: createUserProp, title = 'Buy Tickets', subtitle = 'Step 1 of 8 — Your details' }) => {
   const [touched, setTouched] = useState<Record<'firstName' | 'lastName' | 'email', boolean>>({ 
     firstName: false, 
     lastName: false, 
@@ -18,7 +21,8 @@ const UserDetailsStep: React.FC<UserDetailsStepProps> = ({ user, onUserUpdate, o
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const createUser = useTicketFlowStore((s) => s.createUser);
+  const storeCreateUser = useTicketFlowStore((s) => s.createUser);
+  const createUser = createUserProp ?? storeCreateUser;
 
   const onChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     const { name, value } = e.target;
@@ -63,7 +67,7 @@ const UserDetailsStep: React.FC<UserDetailsStepProps> = ({ user, onUserUpdate, o
     <div className="min-h-screen bg-noahbrave-50 font-body pb-32">
       <div className="checker-top h-3" style={{ backgroundColor: 'var(--brand)' }} />
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <StepHeader title="Buy Tickets" subtitle="Step 1 of 8 — Your details" />
+        <StepHeader title={title} subtitle={subtitle} />
 
         <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-xl border border-noahbrave-200 p-8">
           {errorMessage && (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css'
 import App from './App.tsx'
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom'
 import TicketFlow from './components/ticket-flow/TicketFlow.tsx'
+import SponsorFlow from './components/sponsor-flow/SponsorFlow.tsx'
 import Login from './components/Login.tsx'
 import Auth from './components/Auth.tsx'
 import Dashboard from './components/Dashboard.tsx'
@@ -22,6 +23,8 @@ const router = createBrowserRouter([
   { path: '/account', element: <Account /> },
   { path: '/tickets', element: <Navigate to="/tickets/1" replace /> },
   { path: '/tickets/:step', element: <TicketFlow /> },
+  { path: '/sponsor', element: <Navigate to="/sponsor/1" replace /> },
+  { path: '/sponsor/:step', element: <SponsorFlow /> },
 ])
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/store/sponsorFlow.ts
+++ b/frontend/src/store/sponsorFlow.ts
@@ -1,0 +1,124 @@
+import { create } from 'zustand';
+import type { User } from '../types/ticket';
+import { commitMutation } from 'react-relay';
+import environment from '../relay/environment';
+import { createUserMutation } from '../graphql/mutations/createUser';
+import { getOrCreateCartMutationGQL } from '../graphql/mutations/getOrCreateCart';
+import { addSponsorToCartMutation } from '../graphql/mutations/addSponsorToCart';
+import { removeSponsorFromCartMutation } from '../graphql/mutations/removeSponsorFromCart';
+import { checkoutCartMutation } from '../graphql/mutations/checkoutCart';
+
+import type { createUserMutation as CreateUserMutation } from '../__generated__/createUserMutation.graphql';
+import type { addSponsorToCartMutation as AddSponsorToCartMutation } from '../__generated__/addSponsorToCartMutation.graphql';
+import type { removeSponsorFromCartMutation as RemoveSponsorFromCartMutation } from '../__generated__/removeSponsorFromCartMutation.graphql';
+import type { checkoutCartMutation as CheckoutCartMutation } from '../__generated__/checkoutCartMutation.graphql';
+import type { getOrCreateCartMutation as GetOrCreateCartMutation } from '../__generated__/getOrCreateCartMutation.graphql';
+
+interface SponsorFlowState {
+  currentStep: number;
+  user: User;
+  isCreatingUser: boolean;
+  errorMessage: string | null;
+  cartRefreshKey: number;
+  refreshCart: () => void;
+
+  setUser: (updates: Partial<User>) => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  goToStep: (step: number) => void;
+
+  createUser: (vars: { firstName: string; lastName: string; email: string }) => Promise<User>;
+  ensureCart: () => Promise<void>;
+  addSponsorToCart: (companyName: string, amountDollars: number, companyLogoBase64?: string) => Promise<void>;
+  removeSponsorFromCart: (sponsorId: string) => Promise<void>;
+  checkoutCart: () => Promise<void>;
+}
+
+export const useSponsorFlowStore = create<SponsorFlowState>((set, get) => ({
+  currentStep: 1,
+  user: { firstName: '', lastName: '', email: '' },
+  isCreatingUser: false,
+  errorMessage: null,
+  cartRefreshKey: 0,
+  refreshCart: () => set((s) => ({ cartRefreshKey: s.cartRefreshKey + 1 })),
+
+  setUser: (updates) => set((s) => ({ user: { ...s.user, ...updates } })),
+  nextStep: () => set((s) => ({ currentStep: s.currentStep + 1 })),
+  prevStep: () => set((s) => ({ currentStep: Math.max(1, s.currentStep - 1) })),
+  goToStep: (step) => set(() => ({ currentStep: Math.max(1, step) })),
+
+  createUser: (vars) =>
+    new Promise<User>((resolve, reject) => {
+      set({ isCreatingUser: true, errorMessage: null });
+      commitMutation<CreateUserMutation>(environment, {
+        mutation: createUserMutation,
+        variables: vars,
+        onCompleted: async (response: CreateUserMutation['response']) => {
+          const created = response?.createUser;
+          if (created?.id) {
+            set((s) => ({ user: { ...s.user, id: created.id }, isCreatingUser: false }));
+            try {
+              await get().ensureCart();
+              get().refreshCart();
+            } catch {}
+            resolve(created);
+          } else {
+            const message = 'Unexpected response from server. Please try again.';
+            set({ errorMessage: message, isCreatingUser: false });
+            reject(new Error(message));
+          }
+        },
+        onError: (err: Error) => {
+          let message = 'Something went wrong. Please try again.';
+          if (err?.message) {
+            const match = err.message.match(/Abort\.\d+:\s*(.+)/);
+            message = match ? match[1] : err.message;
+          }
+          set({ errorMessage: message, isCreatingUser: false });
+          reject(new Error(message));
+        },
+      });
+    }),
+
+  ensureCart: () =>
+    new Promise<void>((resolve, reject) => {
+      commitMutation<GetOrCreateCartMutation>(environment, {
+        mutation: getOrCreateCartMutationGQL,
+        variables: {},
+        onCompleted: () => resolve(),
+        onError: (err: Error) => reject(err),
+      });
+    }),
+
+  addSponsorToCart: (companyName, amountDollars, companyLogoBase64) =>
+    new Promise<void>((resolve, reject) => {
+      commitMutation<AddSponsorToCartMutation>(environment, {
+        mutation: addSponsorToCartMutation,
+        variables: { companyName, amountCents: Math.round(amountDollars * 100), companyLogoBase64 },
+        onCompleted: () => { get().refreshCart(); resolve(); },
+        onError: (err: Error) => reject(err),
+      });
+    }),
+
+  removeSponsorFromCart: (sponsorId) =>
+    new Promise<void>((resolve, reject) => {
+      commitMutation<RemoveSponsorFromCartMutation>(environment, {
+        mutation: removeSponsorFromCartMutation,
+        variables: { sponsorId },
+        onCompleted: () => { get().refreshCart(); resolve(); },
+        onError: (err: Error) => reject(err),
+      });
+    }),
+
+  checkoutCart: () =>
+    new Promise<void>((resolve, reject) => {
+      commitMutation<CheckoutCartMutation>(environment, {
+        mutation: checkoutCartMutation,
+        variables: {},
+        onCompleted: () => { get().refreshCart(); resolve(); },
+        onError: (err: Error) => reject(err),
+      });
+    }),
+}));
+
+


### PR DESCRIPTION
## Summary
- add sponsor-only flow and state management
- allow flow components to customize headers and actions
- mention sponsorship option on homepage with link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run lint` *(fails: 32 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdffae16ec83319e7f3b11c6e3cdd4